### PR TITLE
feat: 🎸 check all filtered rows

### DIFF
--- a/src/rowmanager.js
+++ b/src/rowmanager.js
@@ -113,7 +113,13 @@ export default class RowManager {
 
         // update internal map
         if (toggle) {
-            this.checkMap = Array.from(Array(this.getTotalRows())).map(c => value);
+            if (this.datamanager._filteredRows) {
+                this.datamanager._filteredRows.forEach(f => {
+                    this.checkRow(f, toggle);
+                });
+            } else {
+                this.checkMap = Array.from(Array(this.getTotalRows())).map(c => value);
+            }
         } else {
             this.checkMap = [];
         }


### PR DESCRIPTION
When datatable has filters applied, and the "check all" is used, it will check only the rows that match the filters.